### PR TITLE
fix: correct fialed to failed in error message

### DIFF
--- a/subscribe/airport.py
+++ b/subscribe/airport.py
@@ -767,7 +767,7 @@ class AirPort:
                 if os.path.exists(v2ray_file):
                     os.remove(v2ray_file)
 
-                logger.error(f"save file fialed, artifact: {artifact}")
+                logger.error(f"save file failed, artifact: {artifact}")
                 traceback.print_exc()
 
             generate_conf = os.path.join(PATH, "subconverter", "generate.ini")


### PR DESCRIPTION
Correct typo fialed→failed in subscribe/airport.py error logger.

User-facing error message in artifact save path at line 770.